### PR TITLE
Fix `DEPLOY_UNFINISHED` not being copied over to `release`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Update `wp_cli_version` to 2.4.0 ([#1131](https://github.com/roots/trellis/pull/1131))
 * `composer install` without `--no-scripts` during deploy ([#1133](https://github.com/roots/trellis/pull/1133))
 * Allow `composer install` with `--classmap-authoritative` during deploy ([#1132](https://github.com/roots/trellis/pull/1132))
+* Fix `DEPLOY_UNFINISHED` not being copied over to `release` folder (#[1145])(https://github.com/roots/trellis/pull/1145)
 
 ### 1.3.0: December 7th, 2019
 * Add `git_sha` and `release_version` to `.env` on deploy ([#1124](https://github.com/roots/trellis/pull/1124))

--- a/roles/deploy/tasks/prepare.yml
+++ b/roles/deploy/tasks/prepare.yml
@@ -5,11 +5,6 @@
     loop_var: include_path
   tags: deploy-prepare-before
 
-- name: write unfinished file
-  file:
-    path: "{{ project_source_path }}/{{ deploy_helper.unfinished_filename }}"
-    state: touch
-
 - name: Check for project repo subtree
   stat:
     path: "{{ project_source_path }}/{{ project.repo_subtree_path }}"
@@ -37,6 +32,11 @@
   args:
     chdir: "{{ project_source_path }}"
   when: project.repo_subtree_path is defined
+
+- name: write unfinished file
+  file:
+    path: "{{ deploy_helper.new_release_path }}/{{ deploy_helper.unfinished_filename }}"
+    state: touch
 
 - include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_prepare_after | default([]) }}"


### PR DESCRIPTION
The tar generated by git archive doesn't include `DEPLOY_UNFINISHED`
https://github.com/roots/trellis/blob/ab70d8ed84ef54054de2024e5c2639e047c0b905/roles/deploy/tasks/prepare.yml#L29-L39